### PR TITLE
Publish as @alohahealth/matrix-react-sdk scoped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "matrix-react-sdk",
+  "name": "@alohahealth/matrix-react-sdk",
   "version": "0.13.4",
   "description": "SDK for matrix.org using React",
   "author": "matrix.org",
   "repository": {
     "type": "git",
-    "url": "https://github.com/matrix-org/matrix-react-sdk"
+    "url": "https://github.com/AlohaHealth/matrix-react-sdk"
   },
   "license": "Apache-2.0",
   "main": "lib/index.js",


### PR DESCRIPTION
This change configures our fork to be published to the [@alohahealth/matrix-react-sdk](https://www.npmjs.com/package/@alohahealth/matrix-react-sdk) organization scoped NPM repository.